### PR TITLE
fix return of go_venv script

### DIFF
--- a/go_venv.sh
+++ b/go_venv.sh
@@ -83,4 +83,4 @@ check_python_version(){
   fi
 }
 
-main "$@"; exit
+main "$@"; return


### PR DESCRIPTION
calling `exit` will exit the shell, including a calling script,
calling `return` will return the bash function / script, excluding termination of a calling script
