### PR TITLE
devops/dap support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,8 @@
             "request": "launch",
             "program": "${file}",
             "console": "integratedTerminal",
-            "cwd": "${fileDirname}"
+            "cwd": "${fileDirname}",
+            "stopOnEntry": false,
             //"args": [
             //    "${command:pickArgs}"
             //]
@@ -23,7 +24,8 @@
             "request": "launch",
             "program": "${file}",
             "console": "integratedTerminal",
-            "cwd": "${fileDirname}"
+            "cwd": "${fileDirname}",
+            "stopOnEntry": false
             //"args": [
             //    "${command:pickArgs}"
             //]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "request": "launch",
             "program": "${file}",
             "console": "integratedTerminal",
-            "cwd": "${fileDirname}",
+            "cwd": "${fileDirname}"
             //"args": [
             //    "${command:pickArgs}"
             //]
@@ -23,10 +23,10 @@
             "request": "launch",
             "program": "${file}",
             "console": "integratedTerminal",
-            "cwd": "${fileDirname}",
+            "cwd": "${fileDirname}"
             //"args": [
             //    "${command:pickArgs}"
             //]
-        },
+        }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             "program": "${file}",
             "console": "integratedTerminal",
             "cwd": "${fileDirname}",
-            "stopOnEntry": false,
+            "stopOnEntry": false
             //"args": [
             //    "${command:pickArgs}"
             //]

--- a/go_venv.sh
+++ b/go_venv.sh
@@ -14,43 +14,43 @@
 #
 # ******************************************************************************
 
-main(){
+main() {
   venv_dir=./.venv
   venv_prompt=venv
   venv_requirements=requirements.txt
 
   case "$OSTYPE" in
-    msys* | cygwin*)
-      echo "Operating System: WINDOWS"
-      venv_activate=$venv_dir/Scripts/activate
-      ;;
-    *)
-      echo "Operating System: $OSTYPE"
-      venv_activate=$venv_dir/bin/activate
-      ;;
+  msys* | cygwin*)
+    echo "Operating System: WINDOWS"
+    venv_activate=$venv_dir/Scripts/activate
+    ;;
+  *)
+    echo "Operating System: $OSTYPE"
+    venv_activate=$venv_dir/bin/activate
+    ;;
   esac
 
   check_python_version 3 12 1
 
   if ! [ -f "$venv_activate" ]; then
-      echo python venv does not exist
+    echo python venv does not exist
 
-      echo create the python venv locally
-      python3 -m venv --prompt $venv_prompt $venv_dir
+    echo create the python venv locally
+    python3 -m venv --prompt $venv_prompt $venv_dir
 
-      echo activate the venv
-      source $venv_activate
+    echo activate the venv
+    source $venv_activate
 
-      echo install dependencies
-      pip install -r $venv_requirements
+    echo install dependencies
+    pip install -r $venv_requirements
   else
-      echo python venv does exist
+    echo python venv does exist
 
-      echo activate the venv
-      source $venv_activate
+    echo activate the venv
+    source $venv_activate
 
-      echo check and install dependencies
-      pip install -q -r $venv_requirements
+    echo check and install dependencies
+    pip install -q -r $venv_requirements
   fi
 }
 
@@ -62,19 +62,18 @@ main(){
 #
 # example to test for version 3.12.1
 #   check_python_version 3 12 1
-check_python_version(){
+check_python_version() {
   local version_info="$(python3 -c 'import sys; print(sys.version_info[:])')"
   local version_major=$(echo $version_info | sed -n 's/^(\([0-9]*\), \([0-9].*\), \([0-9]*\), \(.*\), \([0-9]*\))$/\1/p')
   local version_minor=$(echo $version_info | sed -n 's/^(\([0-9]*\), \([0-9].*\), \([0-9]*\), \(.*\), \([0-9]*\))$/\2/p')
   local version_patch=$(echo $version_info | sed -n 's/^(\([0-9]*\), \([0-9].*\), \([0-9]*\), \(.*\), \([0-9]*\))$/\3/p')
   echo detected python version: $version_major.$version_minor.$version_patch
 
-  if [ "$version_major" -eq "$1" ] \
-    && { \
-          [ "$version_minor" -eq "$2" ] && [ "$version_patch" -ge "$3" ] \
-      ||  [ "$version_minor" -gt "$2" ]; \
-    }; \
-  then
+  if [ "$version_major" -eq "$1" ] &&
+    {
+      [ "$version_minor" -eq "$2" ] && [ "$version_patch" -ge "$3" ] ||
+        [ "$version_minor" -gt "$2" ]
+    }; then
     echo check against version: $1.$2.$3 passed
     return 0
   else
@@ -83,4 +82,5 @@ check_python_version(){
   fi
 }
 
-main "$@"; return
+main "$@"
+return

--- a/go_venv.sh
+++ b/go_venv.sh
@@ -36,7 +36,7 @@ main() {
     echo python venv does not exist
 
     echo create the python venv locally
-    python3 -m venv --prompt $venv_prompt $venv_dir
+    python -m venv --prompt $venv_prompt $venv_dir
 
     echo activate the venv
     source $venv_activate
@@ -63,7 +63,7 @@ main() {
 # example to test for version 3.12.1
 #   check_python_version 3 12 1
 check_python_version() {
-  local version_info="$(python3 -c 'import sys; print(sys.version_info[:])')"
+  local version_info="$(python -c 'import sys; print(sys.version_info[:])')"
   local version_major=$(echo $version_info | sed -n 's/^(\([0-9]*\), \([0-9].*\), \([0-9]*\), \(.*\), \([0-9]*\))$/\1/p')
   local version_minor=$(echo $version_info | sed -n 's/^(\([0-9]*\), \([0-9].*\), \([0-9]*\), \(.*\), \([0-9]*\))$/\2/p')
   local version_patch=$(echo $version_info | sed -n 's/^(\([0-9]*\), \([0-9].*\), \([0-9]*\), \(.*\), \([0-9]*\))$/\3/p')


### PR DESCRIPTION
Add support for common plugins in IDEs Code Editors, which implement DAP (Debug Adapter Protocol)
Switching venv to use `python.exe` instead of `python3.exe` for Consistency with IDE DAP implementations.
